### PR TITLE
Add canonical tags for flagged pages

### DIFF
--- a/data/news/20220308-FDJ2-Released.yml
+++ b/data/news/20220308-FDJ2-Released.yml
@@ -1,4 +1,5 @@
 title: "FiDef JENtwo Released"
+canonical: "https://www.maat.digital/news/20220308-FDJ2-Released/"
 date: "2022/03/08"
 published: true
 author: "masciarotte"

--- a/source/2bcmulticorr/index.html.erb
+++ b/source/2bcmulticorr/index.html.erb
@@ -2,6 +2,7 @@
 title: "MAAT 2BC multiCORR"
 layout: "data-spy"
 fastspring: "maat-2bcmulticorr-perpetual-license"
+canonical: "https://www.maat.digital/2bcmulticorr/"
 ---
 <section id="home" class="dzsparallaxer auto-init dzsparallaxer---window-height use-loading" style="position: relative; height: 800px;" data-options='{  mode_scroll: "normal" }'>
   <div class="divimage dzsparallaxer--target " data-src="<%= url_for 'assets/images/bg1.jpg' %>" style="width: 100%; height: 130%; background-image: url()">

--- a/source/2buscontrol/index.html.erb
+++ b/source/2buscontrol/index.html.erb
@@ -4,6 +4,7 @@ layout: "data-spy"
 download:
   Installer for macOS: "https://www.maat.digital/dl/2BC-macos.zip"
   Installer for Windows: "https://www.maat.digital/dl/2BC-windows.zip"
+canonical: "https://www.maat.digital/2buscontrol/"
 ---
 
 <section id="home" class="dzsparallaxer auto-init dzsparallaxer---window-height use-loading" style="position: relative; height: 800px;" data-options='{  mode_scroll: "normal" }'>

--- a/source/contact.html.erb
+++ b/source/contact.html.erb
@@ -1,6 +1,7 @@
 ---
 title: "Contact Us"
 image: "bg2.jpg"
+canonical: "https://www.maat.digital/contact/"
 ---
 
 <div class="container">

--- a/source/fidef/index.html.erb
+++ b/source/fidef/index.html.erb
@@ -2,6 +2,7 @@
 title: "MAAT FiDef JENtwo"
 layout: "data-spy"
 fastspring: "maat-fidef-jentwo-perpetual-license"
+canonical: "https://www.maat.digital/fidef/"
 ---
 <section id="home" class="dzsparallaxer auto-init dzsparallaxer---window-height use-loading" style="position: relative; height: 800px;" data-options='{  mode_scroll: "normal" }'>
   <div class="divimage dzsparallaxer--target " data-src="<%= url_for 'assets/images/bg1.jpg' %>" style="width: 100%; height: 130%; background-image: url()">

--- a/source/layouts/blog.erb
+++ b/source/layouts/blog.erb
@@ -15,6 +15,11 @@
 
   <%= content_tag :title, "MAAT News - " + article.title || current_page.data.title || data.site.title %>
 
+  <% canonical_url = article.canonical || current_page.data.canonical %>
+  <% if canonical_url %>
+    <%= tag :link, :rel => "canonical", :href => canonical_url %>
+  <% end %>
+
   <%= favicon_tag "favicons/apple-touch-icon.png", rel: "apple-touch-icon", sizes: "180x180" %>
   <%= favicon_tag "favicons/favicon-32x32.png", rel: "icon", type: "image/png", sizes: "32x32" %>
   <%= favicon_tag "favicons/favicon-16x16.png", rel: "icon", type: "image/png", sizes: "16x16" %>

--- a/source/layouts/data-spy.erb
+++ b/source/layouts/data-spy.erb
@@ -15,6 +15,10 @@
 
   <%= content_tag :title, current_page.data.title || data.site.title %>
 
+  <% if current_page.data.canonical %>
+    <%= tag :link, :rel => "canonical", :href => current_page.data.canonical %>
+  <% end %>
+
   <%= favicon_tag "favicons/apple-touch-icon.png", rel: "apple-touch-icon", sizes: "180x180" %>
   <%= favicon_tag "favicons/favicon-32x32.png", rel: "icon", type: "image/png", sizes: "32x32" %>
   <%= favicon_tag "favicons/favicon-16x16.png", rel: "icon", type: "image/png", sizes: "16x16" %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -15,6 +15,10 @@
 
   <%= content_tag :title, current_page.data.title || data.site.title %>
 
+  <% if current_page.data.canonical %>
+    <%= tag :link, :rel => "canonical", :href => current_page.data.canonical %>
+  <% end %>
+
   <%= favicon_tag "favicons/apple-touch-icon.png", rel: "apple-touch-icon", sizes: "180x180" %>
   <%= favicon_tag "favicons/favicon-32x32.png", rel: "icon", type: "image/png", sizes: "32x32" %>
   <%= favicon_tag "favicons/favicon-16x16.png", rel: "icon", type: "image/png", sizes: "16x16" %>

--- a/source/rsphaseshifter/index.html.erb
+++ b/source/rsphaseshifter/index.html.erb
@@ -3,6 +3,7 @@ title: "MAAT RSPhaseShifter"
 layout: "data-spy"
 fastspring: "maat-rsphaseshifter-perpetual-license"
 
+canonical: "https://www.maat.digital/rsphaseshifter/"
 ---
 
 <section id="home" class="dzsparallaxer auto-init dzsparallaxer---window-height use-loading"

--- a/source/support/index.html.erb
+++ b/source/support/index.html.erb
@@ -1,6 +1,7 @@
 ---
 title: "Support"
 image: "bg2.jpg"
+canonical: "https://www.maat.digital/support/"
 ---
 
 

--- a/source/theqblue/index.html.erb
+++ b/source/theqblue/index.html.erb
@@ -7,6 +7,7 @@ fastspring:
   allEQ: "all-eq-bundle"
   upgrade6: "maat-theqblue6to12-upgrade-perpetual-license"
 
+canonical: "https://www.maat.digital/theqblue/"
 ---
 
 <section id="home" class="dzsparallaxer auto-init dzsparallaxer---window-height use-loading"


### PR DESCRIPTION
Adds explicit canonical tags to the pages that were flagged as missing canonical URL coverage.

This helps search engines identify the preferred URL for each page, reducing the chance of duplicate-content ambiguity and making the site’s canonical signals more consistent across key pages.

- Added canonical URL metadata for the flagged pages.
- Kept canonical paths aligned with the existing public page URLs.
- Limited the change