### PR TITLE
Add llms.txt and llms-full.txt for MAAT.digital

### DIFF
--- a/source/llms-full.txt
+++ b/source/llms-full.txt
@@ -1,12 +1,14 @@
 # MAAT.digital
 
-> MAAT Digital makes pro-audio DSP plugins for mastering and mixing — EQs, loudness/DR meters, utilities, and free tools.
+> MAAT.digital — Sound…Simply Better. Fidelity-first DSP for mastering and mixing: multi-architecture EQs, official DR/Loudness metering, specialized utilities, and free bus tools.
 
-This file expands [llms.txt](https://www.maat.digital/llms.txt) with short factual summaries so agents can answer product and company questions without scraping HTML. The live marketing site is https://www.maat.digital (English). Promo and campaign landings under `/go/`, `/get/`, and `/lm/` are out of scope. Installers and many downloads are hosted separately from this site; start at `/support/` for current installer and manual links.
+This file expands [llms.txt](https://www.maat.digital/llms.txt) with short product and company summaries so agents can answer questions without scraping HTML. The live marketing site is https://www.maat.digital (English). Promo and campaign landings under `/go/`, `/get/`, and `/lm/` are out of scope. Installers and many downloads are hosted separately from this site; start at `/support/` for current installer and manual links.
 
 ## Company
 
-MAAT (MAAT.digital) is a brand of Mastering Academy Germany UG. The company develops pro-audio plug-ins and utilities for metering, EQ, dynamics, and specialized studio workflows. Roots include the Pleasurize Music Foundation and the Mastering Academy. The team presents itself as working audio engineers focused on fidelity and usability.
+MAAT (MAAT.digital) is a brand of Mastering Academy Germany UG. The company develops pro-audio plug-ins and utilities for metering, EQ, and specialized studio workflows, with roots in the Pleasurize Music Foundation and the Mastering Academy. The team presents itself as working audio engineers focused on fidelity and usability — better sound and simpler workflows, not blingy UIs.
+
+Tagline: Sound…Simply Better.
 
 - [Home](https://www.maat.digital/)
 - [About](https://www.maat.digital/about/)
@@ -26,33 +28,33 @@ OEM licensing and co-development cover DSP/measurement IP and white-label produc
 
 ### thEQblue — https://www.maat.digital/theqblue/
 
-Minimum-phase parametric EQ with up to twelve idealized analog-style Architectures (series classic/proportional/const-Q plus parallel FF-FB and LC). Aimed at recording and mixing when you would reach for analog EQ, without analog noise or distortion. Sections can be stereo or M/S; optional FiDef. Sold as thEQblue6 (6 Architectures) or thEQblue12 (all 12).
+Minimum-phase parametric EQ built as a sandbox of idealized analog-style Architectures (series classic/proportional/const-Q plus parallel FF-FB and LC). Aimed at recording, mixing, and mastering when you would reach for analog EQ — without analog noise or distortion. Sections can be stereo or M/S; optional FiDef. Sold as thEQblue6 (6 Architectures) or thEQblue12 (all 12).
 
 ### thEQred — https://www.maat.digital/theqred/
 
-Frequency-domain linear-phase parametric EQ (Algorithmix LinearPhase PEQ Red lineage). Positioned for aesthetic mastering contouring while preserving time relationships of harmonics. Twelve sections; VariSlope continuous-slope shelves/cuts; sample rates up to 384 kHz. Also available in the thEQlp annual subscription with thEQorange.
+Frequency-domain linear-phase parametric EQ (Algorithmix LinearPhase PEQ Red lineage). Positioned for aesthetic mastering-bus contouring while preserving time relationships of harmonics — not a tracking/mixing workhorse. Twelve sections; VariSlope continuous-slope shelves/cuts; sample rates up to 384 kHz. Also available in the thEQlp annual subscription with thEQorange.
 
 ### thEQorange — https://www.maat.digital/theqorange/
 
-Linear-phase parametric EQ (Algorithmix LinearPhase PEQ Orange lineage). Positioned for surgical mastering work—mostly cuts, resonances, declutter, and low-cut—rather than broad aesthetic lifts. Sections assignable L/R or M/S. Also available in the thEQlp subscription with thEQred.
+Time-domain linear-phase parametric EQ (Algorithmix LinearPhase PEQ Orange lineage). Positioned for surgical and remedial mastering — mostly cuts, resonances, declutter, and preferred LP low-cut — rather than broad aesthetic lifts. Sections assignable L/R or M/S. Also available in the thEQlp subscription with thEQred.
 
 ### SantaCruzEQ — https://www.maat.digital/santacruzeq/
 
-Lower-CPU minimum-phase cousin of thEQblue: the same Architecture set, with up to six Sections (versus twelve on blue). SantaCruzEQ6 covers Architectures 1–6; SantaCruzEQ12 covers all twelve. Idealized analog-style PEQs without inherited analog artifacts.
+Affordable, lower-CPU cousin of thEQblue: the same Architecture set, with up to six Sections (versus twelve on blue). SantaCruzEQ6 covers Architectures 1–6; SantaCruzEQ12 covers all twelve. Idealized analog-style PEQs without inherited analog artifacts; does not include thEQblue’s FiDef option or advanced visualizers.
 
 ## Effects and utilities
 
 ### FiDef JENtwo — https://www.maat.digital/fidef/
 
-Standalone cross-platform plug-in of FideliQuest’s FiDef: a low-amplitude, source-correlated psychoacoustic stimulus, not a conventional EQ or dynamics processor. First used inside thEQblue; available alone as JENtwo.
+Standalone cross-platform plug-in of FideliQuest’s FiDef: a low-amplitude, source-correlated psychoacoustic stimulus with multiple Profiles — often described as “dither for your brain,” not a conventional EQ or dynamics processor. First used inside thEQblue; available alone as JENtwo.
 
 ### RSPhaseShifter — https://www.maat.digital/rsphaseshifter/
 
-Official digital recreation of the Roger Schult / German Audio Lab Phase Shifter W2324. Creates a phase-shifted version of the input for alignment, comb/timbre control, subwoofer and fold-down issues, and multi-mic blend.
+Official digital recreation of the Roger Schult / German Audio Lab Phase Shifter W2324. Creates a phase-shifted version of the input for multi-mic and stem alignment, comb/timbre control, subwoofer and fold-down issues, and creative phase tone.
 
 ### MAATgo — https://www.maat.digital/maatgo/
 
-Monitor-controller and goniometer plug-in (and standalone): L/R solo, mono, L−R, swap, polarity invert, balance, and phase-scope display. Aimed at DAW and computer high-resolution listening; sample rates up to 384 kHz.
+Monitor-controller and analog-style goniometer (plugin and standalone): L/R solo, mono, L−R, swap, polarity invert, balance, and phase-scope display. Aimed at DAW and computer high-resolution listening; sample rates up to 384 kHz.
 
 ### MtG — https://www.maat.digital/mtg/
 
@@ -74,11 +76,11 @@ Batch file analyzer companion to DRMeter MkII. Measures mandated R 128 parameter
 
 ### 2BC multiCORR — https://www.maat.digital/2bcmulticorr/
 
-Third-octave multiband correlation meter (31 bands) plus L/R balance, broadband correlation, and five monitor modes (L/R, mono, difference, flip)—extends free 2BusControl. Extra low-band detail for vinyl and LF mono safety; includes standalone.
+Third-octave multiband correlation meter (31 bands) plus L/R balance, broadband correlation, and five monitor modes (L/R, mono, difference, flip) — extends free 2BusControl. Extra low-band detail for vinyl and LF mono safety; includes standalone.
 
 ### DRMeter — https://www.maat.digital/drmeter/
 
-Entry real-time DR estimator (TT Dynamic Range Meter lineage): graphical/numeric DR estimate, SPPM, RMS, overs, and digital black. Not a full R 128 Loudness meter; correlation/mono monitoring moved to free 2BusControl. MkII is the full Loudness successor.
+Entry real-time DR estimator (TT Dynamic Range Meter lineage): graphical/numeric DR estimate, SPPM, RMS, overs, and digital black. Not a full R 128 Loudness meter; correlation/mono monitoring moved to free 2BusControl. Official integrated DRi needs DROffline; MkII is the full Loudness successor.
 
 ### DROffline — https://www.maat.digital/droffline/
 

--- a/source/llms-full.txt
+++ b/source/llms-full.txt
@@ -1,0 +1,106 @@
+# MAAT.digital
+
+> MAAT Digital makes pro-audio DSP plugins for mastering and mixing — EQs, loudness/DR meters, utilities, and free tools.
+
+This file expands [llms.txt](https://www.maat.digital/llms.txt) with short factual summaries so agents can answer product and company questions without scraping HTML. The live marketing site is https://www.maat.digital (English). Promo and campaign landings under `/go/`, `/get/`, and `/lm/` are out of scope. Installers and many downloads are hosted separately from this site; start at `/support/` for current installer and manual links.
+
+## Company
+
+MAAT (MAAT.digital) is a brand of Mastering Academy Germany UG. The company develops pro-audio plug-ins and utilities for metering, EQ, dynamics, and specialized studio workflows. Roots include the Pleasurize Music Foundation and the Mastering Academy. The team presents itself as working audio engineers focused on fidelity and usability.
+
+- [Home](https://www.maat.digital/)
+- [About](https://www.maat.digital/about/)
+- [News](https://www.maat.digital/news/)
+- [Contact](https://www.maat.digital/contact/)
+
+## Support and services
+
+Support covers installation, activation, and product issues. Typical guidance: install the latest build and License Central, try Troubleshooting (often license cache), then FAQ, then email support with OS/DAW/machine detail. Product installers commonly also act as time-limited demos. General (non-support) questions go through marketing contact channels listed on the site.
+
+OEM licensing and co-development cover DSP/measurement IP and white-label products (EQs, measurement, LIN and DRi libraries). Stated kits include LIN OEM (redither/noise shaping) and DRi OEM (standardized subjective dynamic-range metric for integration).
+
+- [Support](https://www.maat.digital/support/)
+- [OEM and Co-Dev](https://www.maat.digital/OEM/)
+
+## Equalizers
+
+### thEQblue — https://www.maat.digital/theqblue/
+
+Minimum-phase parametric EQ with up to twelve idealized analog-style Architectures (series classic/proportional/const-Q plus parallel FF-FB and LC). Aimed at recording and mixing when you would reach for analog EQ, without analog noise or distortion. Sections can be stereo or M/S; optional FiDef. Sold as thEQblue6 (6 Architectures) or thEQblue12 (all 12).
+
+### thEQred — https://www.maat.digital/theqred/
+
+Frequency-domain linear-phase parametric EQ (Algorithmix LinearPhase PEQ Red lineage). Positioned for aesthetic mastering contouring while preserving time relationships of harmonics. Twelve sections; VariSlope continuous-slope shelves/cuts; sample rates up to 384 kHz. Also available in the thEQlp annual subscription with thEQorange.
+
+### thEQorange — https://www.maat.digital/theqorange/
+
+Linear-phase parametric EQ (Algorithmix LinearPhase PEQ Orange lineage). Positioned for surgical mastering work—mostly cuts, resonances, declutter, and low-cut—rather than broad aesthetic lifts. Sections assignable L/R or M/S. Also available in the thEQlp subscription with thEQred.
+
+### SantaCruzEQ — https://www.maat.digital/santacruzeq/
+
+Lower-CPU minimum-phase cousin of thEQblue: the same Architecture set, with up to six Sections (versus twelve on blue). SantaCruzEQ6 covers Architectures 1–6; SantaCruzEQ12 covers all twelve. Idealized analog-style PEQs without inherited analog artifacts.
+
+## Effects and utilities
+
+### FiDef JENtwo — https://www.maat.digital/fidef/
+
+Standalone cross-platform plug-in of FideliQuest’s FiDef: a low-amplitude, source-correlated psychoacoustic stimulus, not a conventional EQ or dynamics processor. First used inside thEQblue; available alone as JENtwo.
+
+### RSPhaseShifter — https://www.maat.digital/rsphaseshifter/
+
+Official digital recreation of the Roger Schult / German Audio Lab Phase Shifter W2324. Creates a phase-shifted version of the input for alignment, comb/timbre control, subwoofer and fold-down issues, and multi-mic blend.
+
+### MAATgo — https://www.maat.digital/maatgo/
+
+Monitor-controller and goniometer plug-in (and standalone): L/R solo, mono, L−R, swap, polarity invert, balance, and phase-scope display. Aimed at DAW and computer high-resolution listening; sample rates up to 384 kHz.
+
+### MtG — https://www.maat.digital/mtg/
+
+Gap-fill / loop plug-in for dialog, foley, beds, podcast, and broadcast: auto-fills gaps of any length with looped audio, with loop editing and gain. Sample rates up to 384 kHz.
+
+### LIN Family — https://www.maat.digital/lin/
+
+Family of redither / word-length-reduction plug-ins for the last stage before fixed-point delivery. LINone: essential first-order noise-shaped dither (16/24). LINpro (stereo) and LINSurround (multichannel): more noise-shaping choices (including TPD / weighted TPD and higher-order psychoacoustic shapes), bit-depth options, and rounding versus truncation.
+
+## Measurement
+
+### DRMeter MkII — https://www.maat.digital/drm2/
+
+Real-time Loudness and DR meter: official integrated DRi plus EBU R 128 / ATSC A/85 metrics, L/R channel detail, Dynamic Deviation, Relative and Absolute scales, PSR/LRA, optional AAC monitoring path; also available native/standalone. Often sold in a DR2 bundle with DROffline MkII.
+
+### DROffline MkII — https://www.maat.digital/dro2/
+
+Batch file analyzer companion to DRMeter MkII. Measures mandated R 128 parameters, official DRi, PSR, and many other metrics; single file or directory; text/TSV logs with optional metadata; drag-and-drop workflow with DRM2.
+
+### 2BC multiCORR — https://www.maat.digital/2bcmulticorr/
+
+Third-octave multiband correlation meter (31 bands) plus L/R balance, broadband correlation, and five monitor modes (L/R, mono, difference, flip)—extends free 2BusControl. Extra low-band detail for vinyl and LF mono safety; includes standalone.
+
+### DRMeter — https://www.maat.digital/drmeter/
+
+Entry real-time DR estimator (TT Dynamic Range Meter lineage): graphical/numeric DR estimate, SPPM, RMS, overs, and digital black. Not a full R 128 Loudness meter; correlation/mono monitoring moved to free 2BusControl. MkII is the full Loudness successor.
+
+### DROffline — https://www.maat.digital/droffline/
+
+Entry batch utility for official integrated DRi (plus SPPM/RMS); single file or directory. Does not measure lossy files (MP3/AAC). MkII adds modern Loudness/True Peak and more metrics.
+
+## Free tools
+
+### 2BusControl — https://www.maat.digital/2buscontrol/
+
+Free stereo-bus monitor controller with balance and correlation meters. Modes: L/R solo, mono, difference (M/S), L/R flip. Lightweight UI for master-bus checking.
+
+### GŌN — https://www.maat.digital/gon/
+
+Free goniometer / phase-scope plug-in (analog oscilloscope-style Lissajous). Autogain and preference-only display controls (gain, focus, phosphor, style, persistence). Lightweight; major plug-in formats.
+
+## Optional policy and commerce pages
+
+- [Edu pricing](https://www.maat.digital/edu-pricing/)
+- [Money-back](https://www.maat.digital/money-back/)
+- [Copy protection](https://www.maat.digital/copy-protection/)
+- [Upgrade](https://www.maat.digital/upgrade/)
+- [Dongle](https://www.maat.digital/dongle/)
+- [Privacy](https://www.maat.digital/privacy/)
+- [Terms](https://www.maat.digital/terms/)
+- [Imprint](https://www.maat.digital/imprint/)

--- a/source/llms.txt
+++ b/source/llms.txt
@@ -1,0 +1,57 @@
+# MAAT.digital
+
+> MAAT Digital makes pro-audio DSP plugins for mastering and mixing — EQs, loudness/DR meters, utilities, and free tools.
+
+This is the English marketing and product site for MAAT (a brand of Mastering Academy Germany UG), at https://www.maat.digital. Product pages live under short path slugs (for example `/theqorange/`). Support, installers, and manuals are centralized on `/support/`. Promo and campaign landings under `/go/`, `/get/`, and `/lm/` are out of scope for this index. For longer product and company summaries, see [llms-full.txt](https://www.maat.digital/llms-full.txt).
+
+## Company
+
+- [Home](https://www.maat.digital/): MAAT.digital site home and product overview
+- [About](https://www.maat.digital/about/): Company story, mission, team, and advisory board
+- [News](https://www.maat.digital/news/): Product and company news
+- [Contact](https://www.maat.digital/contact/): General contact
+
+## Equalizers
+
+- [thEQblue](https://www.maat.digital/theqblue/): Minimum-phase parametric EQ with up to twelve idealized analog-style Architectures
+- [thEQred](https://www.maat.digital/theqred/): Linear-phase parametric EQ for aesthetic mastering contouring
+- [thEQorange](https://www.maat.digital/theqorange/): Linear-phase parametric EQ for surgical mastering cuts and cleanup
+- [SantaCruzEQ](https://www.maat.digital/santacruzeq/): Lower-CPU minimum-phase EQ sharing thEQblue’s Architecture set
+
+## Effects and utilities
+
+- [FiDef JENtwo](https://www.maat.digital/fidef/): Standalone FiDef psychoacoustic stimulus plugin
+- [RSPhaseShifter](https://www.maat.digital/rsphaseshifter/): Digital recreation of the Roger Schult / German Audio Lab Phase Shifter W2324
+- [MAATgo](https://www.maat.digital/maatgo/): Monitor controller and goniometer for DAW and computer listening
+- [MtG](https://www.maat.digital/mtg/): Gap-fill / loop plugin for dialog, foley, beds, and broadcast
+- [LIN Family](https://www.maat.digital/lin/): Redither and word-length-reduction plugins (LINone, LINpro, LINSurround)
+
+## Measurement
+
+- [DRMeter MkII](https://www.maat.digital/drm2/): Real-time Loudness and official DRi metering
+- [DROffline MkII](https://www.maat.digital/dro2/): Batch file analyzer companion to DRMeter MkII
+- [2BC multiCORR](https://www.maat.digital/2bcmulticorr/): Third-octave multiband correlation meter with monitor modes
+- [DRMeter](https://www.maat.digital/drmeter/): Entry real-time DR estimator (TT Dynamic Range lineage)
+- [DROffline](https://www.maat.digital/droffline/): Entry batch utility for official integrated DRi
+
+## Free tools
+
+- [2BusControl](https://www.maat.digital/2buscontrol/): Free stereo-bus monitor controller with balance and correlation meters
+- [GŌN](https://www.maat.digital/gon/): Free goniometer / phase-scope plugin
+
+## Support and services
+
+- [Support](https://www.maat.digital/support/): Installation, activation, troubleshooting, FAQs, installers, and manuals
+- [OEM and Co-Dev](https://www.maat.digital/OEM/): OEM licensing and co-development for DSP and measurement IP
+
+## Optional
+
+- [llms-full.txt](https://www.maat.digital/llms-full.txt): Longer company and product summaries for deeper ingestion
+- [Edu pricing](https://www.maat.digital/edu-pricing/): Educational pricing policy
+- [Money-back](https://www.maat.digital/money-back/): Money-back / satisfaction policy
+- [Copy protection](https://www.maat.digital/copy-protection/): Licensing and copy-protection overview
+- [Upgrade](https://www.maat.digital/upgrade/): Upgrade paths between products
+- [Dongle](https://www.maat.digital/dongle/): Hardware dongle information
+- [Privacy](https://www.maat.digital/privacy/): Privacy policy
+- [Terms](https://www.maat.digital/terms/): Terms of use
+- [Imprint](https://www.maat.digital/imprint/): Legal imprint

--- a/source/llms.txt
+++ b/source/llms.txt
@@ -1,43 +1,43 @@
 # MAAT.digital
 
-> MAAT Digital makes pro-audio DSP plugins for mastering and mixing — EQs, loudness/DR meters, utilities, and free tools.
+> MAAT.digital — Sound…Simply Better. Fidelity-first DSP for mastering and mixing: multi-architecture EQs, official DR/Loudness metering, specialized utilities, and free bus tools.
 
 This is the English marketing and product site for MAAT (a brand of Mastering Academy Germany UG), at https://www.maat.digital. Product pages live under short path slugs (for example `/theqorange/`). Support, installers, and manuals are centralized on `/support/`. Promo and campaign landings under `/go/`, `/get/`, and `/lm/` are out of scope for this index. For longer product and company summaries, see [llms-full.txt](https://www.maat.digital/llms-full.txt).
 
 ## Company
 
-- [Home](https://www.maat.digital/): MAAT.digital site home and product overview
-- [About](https://www.maat.digital/about/): Company story, mission, team, and advisory board
-- [News](https://www.maat.digital/news/): Product and company news
+- [Home](https://www.maat.digital/): MAAT.digital home — Sound…Simply Better
+- [About](https://www.maat.digital/about/): Fidelity-first company story, mission, team, and advisory board
+- [News](https://www.maat.digital/news/): Product launches and company news
 - [Contact](https://www.maat.digital/contact/): General contact
 
 ## Equalizers
 
-- [thEQblue](https://www.maat.digital/theqblue/): Minimum-phase parametric EQ with up to twelve idealized analog-style Architectures
-- [thEQred](https://www.maat.digital/theqred/): Linear-phase parametric EQ for aesthetic mastering contouring
-- [thEQorange](https://www.maat.digital/theqorange/): Linear-phase parametric EQ for surgical mastering cuts and cleanup
-- [SantaCruzEQ](https://www.maat.digital/santacruzeq/): Lower-CPU minimum-phase EQ sharing thEQblue’s Architecture set
+- [thEQblue](https://www.maat.digital/theqblue/): Minimum-phase “analog Architecture” EQ (6 or 12 idealizations) with optional FiDef — when you’d reach for analog, without analog noise
+- [thEQred](https://www.maat.digital/theqred/): Frequency-domain linear-phase mastering EQ for aesthetic contouring (VariSlope); also via thEQlp with orange
+- [thEQorange](https://www.maat.digital/theqorange/): Time-domain linear-phase mastering EQ for surgical cuts, declutter, and LP low-cut; also via thEQlp with red
+- [SantaCruzEQ](https://www.maat.digital/santacruzeq/): Affordable lower-CPU cousin of thEQblue — same Architectures, six Sections (not twelve), SCEQ6/12
 
 ## Effects and utilities
 
-- [FiDef JENtwo](https://www.maat.digital/fidef/): Standalone FiDef psychoacoustic stimulus plugin
-- [RSPhaseShifter](https://www.maat.digital/rsphaseshifter/): Digital recreation of the Roger Schult / German Audio Lab Phase Shifter W2324
-- [MAATgo](https://www.maat.digital/maatgo/): Monitor controller and goniometer for DAW and computer listening
-- [MtG](https://www.maat.digital/mtg/): Gap-fill / loop plugin for dialog, foley, beds, and broadcast
-- [LIN Family](https://www.maat.digital/lin/): Redither and word-length-reduction plugins (LINone, LINpro, LINSurround)
+- [FiDef JENtwo](https://www.maat.digital/fidef/): Standalone FideliQuest FiDef — source-correlated psychoacoustic stimulus (not EQ/dynamics), multi-profile
+- [RSPhaseShifter](https://www.maat.digital/rsphaseshifter/): Official digital recreation of Roger Schult W2324 for multi-mic/stem alignment and creative phase tone
+- [MAATgo](https://www.maat.digital/maatgo/): Monitor controller + goniometer for DAW and HRA computer listening (plugin + standalone)
+- [MtG](https://www.maat.digital/mtg/): Gap-fill/loop plugin for dialog, foley, beds, podcast, and broadcast
+- [LIN Family](https://www.maat.digital/lin/): Last-in-chain redither/WLR — LINone, LINpro (stereo), LINSurround (multichannel)
 
 ## Measurement
 
-- [DRMeter MkII](https://www.maat.digital/drm2/): Real-time Loudness and official DRi metering
-- [DROffline MkII](https://www.maat.digital/dro2/): Batch file analyzer companion to DRMeter MkII
-- [2BC multiCORR](https://www.maat.digital/2bcmulticorr/): Third-octave multiband correlation meter with monitor modes
-- [DRMeter](https://www.maat.digital/drmeter/): Entry real-time DR estimator (TT Dynamic Range lineage)
-- [DROffline](https://www.maat.digital/droffline/): Entry batch utility for official integrated DRi
+- [DRMeter MkII](https://www.maat.digital/drm2/): Real-time official DRi + R128/A85 Loudness with Dynamic Deviation; often sold in DR2 bundle
+- [DROffline MkII](https://www.maat.digital/dro2/): Batch analyzer companion — R128, official DRi, PSR, logs; single file or directory
+- [2BC multiCORR](https://www.maat.digital/2bcmulticorr/): Paid 31-band correlation meter with 2BusControl monitor modes (vinyl/LF mono checks)
+- [DRMeter](https://www.maat.digital/drmeter/): Entry real-time DR estimator (TT Dynamic Range lineage); official DRi needs DROffline
+- [DROffline](https://www.maat.digital/droffline/): Entry batch official DRi (+ SPPM/RMS); does not measure lossy MP3/AAC
 
 ## Free tools
 
 - [2BusControl](https://www.maat.digital/2buscontrol/): Free stereo-bus monitor controller with balance and correlation meters
-- [GŌN](https://www.maat.digital/gon/): Free goniometer / phase-scope plugin
+- [GŌN](https://www.maat.digital/gon/): Free analog-style goniometer / phase-scope for stereo-bus visualization
 
 ## Support and services
 

--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow:
+
+Sitemap: https://www.maat.digital/sitemap.xml


### PR DESCRIPTION
## Summary
- Add curated `/llms.txt` as an LLM/agent map of company, product, and support pages
- Add companion `/llms-full.txt` with short factual product and company blurbs
- Declare `Sitemap:` in `robots.txt`

## Test plan
- [x] Local Middleman build emits `build/llms.txt` and `build/llms-full.txt` at site root without layout
- [ ] After merge/deploy, `curl -I https://www.maat.digital/llms.txt` returns 200
- [ ] Spot-check linked product URLs resolve